### PR TITLE
1.0.2

### DIFF
--- a/Scripts/Source/User/WorkshopPlus/ActionManager.psc
+++ b/Scripts/Source/User/WorkshopPlus/ActionManager.psc
@@ -27,6 +27,10 @@ Int Property Action_Destroy = 2 autoReadOnly
 Int Property Action_Move = 3 autoReadOnly
 
 
+int iTimerID_DoubleCheckDuplicationHolders = 101 Const
+
+String sThreadID_ObjectCopied = "WSPlus_ObjectCopied"
+
 ; ---------------------------------------------
 ; Editor Properties 
 ; ---------------------------------------------
@@ -46,6 +50,12 @@ Group Assets
 	FormList Property SkipForms Auto Const
 	{ Formlist of objects we won't record history on }
 	Form Property Thread_RecordPosition Auto Const
+	Form Property Thread_CopyObject Auto Const Mandatory
+	{ 1.0.2 - Setting up object copy thread to make cloning handled layers faster }
+	Form Property UndoHelperForm Auto Const Mandatory
+	{ 1.0.2 - Scripted object used to handle undo tasks on large groups of items }
+	EffectShader Property ShaderFlashComplete Auto Const Mandatory
+	{ 1.0.2 - Want to make sure player knows when cloning is complete }
 EndGroup
 
 Group ActorValues
@@ -57,6 +67,10 @@ Group ActorValues
 	ActorValue Property avLastAngZ Auto Const
 	ActorValue Property avLastScale Auto Const
 	ActorValue Property PowerRequired Auto Const
+	ActorValue Property LayerIDAV Auto Const
+	{ 1.0.2 - Used to check the layer ID for bulk undo/redo operations }
+	ActorValue Property RecordLayerIDAV Auto Const
+	{ 1.0.2 - Used to remember the layer ID for bulk undo/redo operations }
 EndGroup
 
 Group Keywords
@@ -64,17 +78,46 @@ Group Keywords
 	Keyword Property PowerConnection Auto Const
 	Keyword Property WorkshopItemKeyword Auto Const
 	Keyword Property TemporarilyMoved Auto Const Mandatory
+	Keyword Property WorkshopStackedItemParentKEYWORD Auto Const Mandatory
+	Keyword Property LayerHolderLinkKeyword Auto Const Mandatory
+	{ 1.0.2 - Same as LayerManager }
+	Keyword Property UndoHelperKeyword Auto Const Mandatory
+	{ 1.0.2 - Keyword to identify an object as an Undo Helper }
+	Keyword Property UndoHelperLinkKeyword Auto Const Mandatory
+	{ 1.0.2 - Keyword to attach items to undo helpers }
+	Keyword Property LayerHandleKeyword Auto Const Mandatory
+	{ 1.0.2 - Keyword to identify an object as a layer handle }
 EndGroup
 
 Group Aliases
 	RefCollectionAlias Property ScrappableCollection Auto Const
 	{ Scrappable objects found by our ObjectFinder quest so we can record the location for the sake of Undo records }
+	RefCollectionAlias Property UndoHelperCollection Auto Const
+	{ 1.0.2 - Holds references to UndoHelpers - when clearing undo history, we'll release these }
+	ReferenceAlias Property SafeSpawnPoint Auto Const
+	{ 1.0.2 - Needed for spawning undo helpers }
+	RefCollectionAlias[] Property LayerItemDuplicationHolders Auto Const Mandatory
+	{ 1.0.2 - We'll store layer items here temporarily during duplication so we don't overwhelm the quest with a ton of threaded calls to lock functions }
 EndGroup
 
 
 Group Messages
 	Message Property UndoSupportReady Auto Const
 	Message Property MustBeInWorkshopModeToUseHotkeys Auto Const Mandatory
+	Message Property CloneLayerHandleOptions Auto Const Mandatory
+	Message Property MustBeInSettlement Auto Const Mandatory
+	Message Property UndoBusy Auto Const Mandatory
+	Message Property UndoMessage Auto Const Mandatory
+	Message Property NothingToUndoMessage Auto Const Mandatory
+	Message Property RedoBusy Auto Const Mandatory
+	Message Property RedoMessage Auto Const Mandatory
+	Message Property NothingToRedoMessage Auto Const Mandatory
+EndGroup
+
+
+Group Settings
+	GlobalVariable Property Setting_CloneLayerHandleMethod Auto Const Mandatory
+	{ 1.0.2 - Gives the player control for how cloning layer handles works. 0 = Just create on current layer, 1 = Create new layer if possible, 2 = ask me each time }
 EndGroup
 
 
@@ -85,6 +128,8 @@ EndGroup
 
 Bool[] bRecordInitialPositionsBlock
 Bool bRegisterWorkshopsBlock = false
+Bool bAddingDuplicatesToLayersBlock = false
+Bool bUndoRedoBlock = false ; 1.0.2 - Prevent spamming which will cause unexpected behavior
 
 BuildAction[] History01
 BuildAction[] History02
@@ -104,7 +149,11 @@ Int iMaxArrays = 10 ; Should always be equal to the number of history arrays
 ArraySlot LastUsed ; Used to determine where to record next
 ArraySlot Pointer ; Used to prevent Undo/Redo from going to far
 
-ObjectReference kGrabbedRef
+ObjectReference Property kGrabbedRef Auto Hidden ; 1.0.2 Converted to property as we're going to need access this from some other functions
+
+
+; 1.0.2 - UndoHelpers will allow undoing large duplication actions
+ObjectReference[] Property UndoHelperHolder Auto Hidden
 
 ; ---------------------------------------------
 ; Events
@@ -115,22 +164,52 @@ Event ObjectReference.OnWorkshopObjectGrabbed(ObjectReference akWorkshopRef, Obj
 EndEvent
 
 
+
 Event ObjectReference.OnWorkshopObjectPlaced(ObjectReference akWorkshopRef, ObjectReference akReference)
+	if(kGrabbedRef == akReference) ; 1.0.2 - Ensure we clear the grabbed ref once it's no longer grabbed
+		kGrabbedRef = None
+	endif
+	
 	WorkshopScript asWorkshop = akWorkshopRef as WorkshopScript
 	
-	CreateHistory(akReference, asWorkshop.GetWorkshopID(), Action_Create)
+	if(akReference.GetLinkedRef(WorkshopStackedItemParentKEYWORD) == None && akReference.GetLinkedRef(UndoHelperLinkKeyword) == None)
+		CreateHistory(akReference, asWorkshop.GetWorkshopID(), Action_Create)
+	endif
 EndEvent
 
 Event ObjectReference.OnWorkshopObjectMoved(ObjectReference akWorkshopRef, ObjectReference akReference)
+	if(kGrabbedRef == akReference) ; 1.0.2 - Ensure we clear the grabbed ref once it's no longer grabbed
+		kGrabbedRef = None
+	endif
+	
 	WorkshopScript asWorkshop = akWorkshopRef as WorkshopScript
 	
-	CreateHistory(akReference, asWorkshop.GetWorkshopID(), Action_Move)
+	if(akReference.GetLinkedRef(UndoHelperLinkKeyword) != None)
+		; Disconnect from the UndoHelperKeyword
+		akReference.SetLinkedRef(None, UndoHelperLinkKeyword)
+	endif
+	
+	; 1.0.2 - Recording movement of all stacked items is spotty at best and the goal going forward is to record batch actions with UndoHelpers
+	if(akReference.GetLinkedRef(WorkshopStackedItemParentKEYWORD) == None)
+		CreateHistory(akReference, asWorkshop.GetWorkshopID(), Action_Move)
+	endif
 EndEvent
 
 Event ObjectReference.OnWorkshopObjectDestroyed(ObjectReference akWorkshopRef, ObjectReference akReference)
+	if(kGrabbedRef == akReference) ; 1.0.2 - Ensure we clear the grabbed ref once it's no longer grabbed
+		kGrabbedRef = None
+	endif
+	
 	WorkshopScript asWorkshop = akWorkshopRef as WorkshopScript
 	
-	CreateHistory(akReference, asWorkshop.GetWorkshopID(), Action_Destroy)
+	if(akReference.GetLinkedRef(UndoHelperLinkKeyword) != None)
+		; Disconnect from the UndoHelperKeyword
+		akReference.SetLinkedRef(None, UndoHelperLinkKeyword)
+	endif
+	
+	if( ! akReference.HasKeyword(LayerHandleKeyword))
+		CreateHistory(akReference, asWorkshop.GetWorkshopID(), Action_Destroy)
+	endif
 EndEvent
 
 
@@ -158,6 +237,25 @@ Event WorkshopFramework:MainQuest.PlayerExitedSettlement(WorkshopFramework:MainQ
 EndEvent
 
 
+
+; 1.0.2 - Monitoring for our threads so we can add duplicated items to the appropriate layers
+Event WorkshopFramework:Library:ThreadRunner.OnThreadCompleted(WorkshopFramework:Library:ThreadRunner akThreadRunner, Var[] akargs)
+	; akargs[0] = sCustomCallCallbackID, akargs[1] = iCallbackID, akargs[2] = ThreadRef
+	String sCustomCallCallbackID = akargs[0] as String
+	
+	;ModTrace("Received event with callback ID: " + sCustomCallCallbackID)
+	if(sCustomCallCallbackID == sThreadID_ObjectCopied)
+		AddDuplicatesToLayers()
+	endif
+EndEvent
+
+
+Event OnTimer(Int aiTimerID)
+	if(aiTimerID == iTimerID_DoubleCheckDuplicationHolders)
+		AddDuplicatesToLayers()
+	endif
+EndEvent
+
 ; ---------------------------------------------
 ; Functions
 ; ---------------------------------------------
@@ -176,6 +274,7 @@ Function HandleQuestInit()
 	RegisterForCustomEvent(WSFW_Main, "PlayerExitedSettlement")
 	
 	RegisterForAllWorkshopEvents()
+	ThreadManager.RegisterForCallbackThreads(Self)
 EndFunction	
 
 
@@ -193,7 +292,13 @@ Function HandleGameLoaded()
 EndFunction
 
 
-
+Function HandleInstallModChanges()
+	if(iInstalledVersion < 3) ; 1.0.2 - We're going to use the thread manager for handling batch duplication of items
+		ThreadManager.RegisterForCallbackThreads(Self)
+	endif
+	
+	Parent.HandleInstallModChanges()
+EndFunction
 
 
 Function RegisterForAllWorkshopEvents()
@@ -283,10 +388,46 @@ Function ClearHistory()
 	
 	LastUsed = new ArraySlot
 	Pointer = new ArraySlot
+	
+	; 1.0.2 - Clear Undo Helpers
+	UndoHelperHolder = new ObjectReference[0]
+	
+	int i = UndoHelperCollection.GetCount()
+	
+	while(i > 0)
+		ObjectReference kUndoHelperRef = UndoHelperCollection.GetAt(0)
+		
+		if(kUndoHelperRef)
+			ObjectReference[] kLinkedRefs = kUndoHelperRef.GetLinkedRefChildren(UndoHelperLinkKeyword)
+			if(kLinkedRefs.Length > 0)
+				int j = 0
+				while(j < kLinkedRefs.Length)
+					kLinkedRefs[i].SetLinkedRef(None, UndoHelperLinkKeyword)
+					
+					j += 1
+				endWhile
+			endif
+			
+			UndoHelperCollection.RemoveRef(kUndoHelperRef)
+			kUndoHelperRef.Disable(false)
+			kUndoHelperRef.Delete()
+		endif
+		
+		i -= 1
+	endWhile
 EndFunction
 
 
 Function CreateHistory(ObjectReference akObjectRef, Int aiWorkshopID, Int aiActionType)
+	if( ! akObjectRef.HasKeyword(UndoHelperKeyword) && akObjectRef.GetLinkedRef(UndoHelperLinkKeyword) != None)
+		return ; This object is part of an undo helper group - we want them handled by the undo helper
+	endif
+	
+	if(akObjectRef.HasKeyword(LayerHandleKeyword))
+		; TODO: Add support for undo/redo of LinkHandle movement
+		return
+	endif
+	
 	Form formBase = akObjectRef.GetBaseObject()
 	
 	if(SkipForms.Find(formBase) >= 0)
@@ -295,6 +436,11 @@ Function CreateHistory(ObjectReference akObjectRef, Int aiWorkshopID, Int aiActi
 	endif
 
 	ArraySlot WhichSlot = new ArraySlot
+	
+	if( ! History01 || History01.Length < 128)
+		; Not initialized yet
+		ClearHistory()
+	endif
 	
 	if(History01[0].iAction <= 0)
 		;Debug.MessageBox("Initializing LastUsed and Pointer")
@@ -503,18 +649,39 @@ BuildAction Function GetAction(Int aiArrayNum, Int aiIndex)
 EndFunction
 
 
-Function Undo()
-	if( ! WorkshopFramework:WSFW_API.IsPlayerInWorkshopMode())
-		Debug.MessageBox("Player is not in workshop mode.")
-		return
+Function PrepareUndoHelper(Int aiWorkshopID, Int aiLayerIndex)
+	if( ! UndoHelperHolder || UndoHelperHolder.Length == 0)
+		UndoHelperHolder = new ObjectReference[LayerManager.iMaxLayers + 1]
 	endif
 	
+	ObjectReference kSpawnAt = SafeSpawnPoint.GetRef()
+	
+	if(kSpawnAt)
+		ObjectReference kTemp = kSpawnAt.PlaceAtMe(UndoHelperForm, abDeleteWhenAble = false)
+		UndoHelperCollection.AddRef(kTemp)
+		UndoHelperHolder[aiLayerIndex] = kTemp
+		
+		CreateHistory(kTemp, aiWorkshopID, Action_Create)
+	endif
+EndFunction
+
+
+Function Undo()
 	WorkshopScript thisWorkshop = WorkshopParent.CurrentWorkshop.GetRef() as WorkshopScript
 	
 	if( ! thisWorkshop)
-		Debug.MessageBox("Could not find settlement.")
+		MustBeInSettlement.Show()
+		
 		return
 	endif
+	
+	if(bUndoRedoBlock)
+		UndoBusy.Show()
+		
+		return
+	endif
+	
+	bUndoRedoBlock = true
 	
 	Int iWorkshopID = thisWorkshop.GetWorkshopID()
 	
@@ -523,16 +690,16 @@ Function Undo()
 	Pointer = FindHistorySlot(Pointer.iArrayNum, Pointer.iIndex, false, iWorkshopID)
 	
 	if(Pointer.iIndex >= 0)
-		Debug.Notification("Undoing action " + Pointer.iArrayNum + "." + Pointer.iIndex)
+		UndoMessage.Show()
 		ApplyAction(GetAction(Pointer.iArrayNum, Pointer.iIndex), true)
 		Pointer = IncrementSlot(Pointer.iArrayNum, Pointer.iIndex, false)
-		
-		return
 	else
 		Pointer = HoldPointer
+		
+		NothingToUndoMessage.Show()
 	endif
 	
-	Debug.MessageBox("Nothing to Undo.")
+	bUndoRedoBlock = false
 EndFunction
 
 
@@ -540,9 +707,18 @@ Function Redo()
 	WorkshopScript thisWorkshop = WorkshopParent.CurrentWorkshop.GetRef() as WorkshopScript
 	
 	if( ! thisWorkshop)
-		Debug.MessageBox("Could not find settlement.")
+		MustBeInSettlement.Show()
+		
 		return
 	endif
+	
+	if(bUndoRedoBlock)
+		RedoBusy.Show()
+		
+		return
+	endif
+	
+	bUndoRedoBlock = true
 	
 	Int iWorkshopID = thisWorkshop.GetWorkshopID()
 	
@@ -552,15 +728,17 @@ Function Redo()
 	Pointer = FindHistorySlot(Pointer.iArrayNum, Pointer.iIndex, true, iWorkshopID)
 		
 	if(Pointer.iIndex >= 0)
-		Debug.Notification("Redoing action " + Pointer.iArrayNum + "." + Pointer.iIndex)
+		;Debug.Notification("Redoing action " + Pointer.iArrayNum + "." + Pointer.iIndex)
 		ApplyAction(GetAction(Pointer.iArrayNum, Pointer.iIndex))
 		
-		return
+		RedoMessage.Show()
 	else
 		Pointer = HoldPointer
+		
+		NothingToRedoMessage.Show()
 	endif
 	
-	Debug.MessageBox("Nothing to Redo.")
+	bUndoRedoBlock = false
 EndFunction
 
 
@@ -582,7 +760,7 @@ Function ApplyAction(BuildAction aAction, Bool bReverse = false)
 		sActionMessage += "Destroy action."
 	endif
 	
-	ModTrace("[WS Plus]" + sActionMessage)
+	ModTrace("[WS Plus]" + sActionMessage + " on object " + aAction.ObjectRef)
 
 
 		; Before starting, clear power
@@ -601,137 +779,180 @@ Function ApplyAction(BuildAction aAction, Bool bReverse = false)
 		endif
 	endif
 	
-
-	if(( ! bReverse && aAction.iAction == Action_Destroy) || (bReverse && aAction.iAction == Action_Create))
-		; Scrap this ref
-		int iLayerID = aAction.ObjectRef.GetValue(LayerManager.LayerID) as Int
-		
-		WorkshopParent.RemoveObjectPUBLIC(aAction.ObjectRef, thisWorkshop)
-		aAction.ObjectRef.Disable()		
-		aAction.ObjectRef.SetLinkedRef(None, WorkshopItemKeyword)
-		
-		WorkshopPlus:WorkshopLayer thisLayer = LayerManager.GetLayerFromID(iLayerID, thisWorkshop)
-		if(thisLayer)
-			LayerManager.RemoveItemFromLayer_Lock(aAction.ObjectRef, thisLayer)
-		endif
-	elseif(( ! bReverse && aAction.iAction == Action_Create) || (bReverse && aAction.iAction == Action_Destroy) || aAction.iAction == Action_Move)
-		Float[] f3dData = new Float[7]
-		int iLayerID = -1
-		
-		if(bReverse && aAction.iAction == Action_Move)
-			;Debug.MessageBox("Using previous data - " + aAction.lastPosZ + " rather than " + aAction.posZ)
-			; Grab previous coordinates from object AVs
-			f3dData[0] = aAction.lastPosX
-			f3dData[1] = aAction.lastPosY
-			f3dData[2] = aAction.lastPosZ
-			f3dData[3] = aAction.lastAngX
-			f3dData[4] = aAction.lastAngY
-			f3dData[5] = aAction.lastAngZ
-			f3dData[6] = aAction.lastfScale
-		else
-			f3dData[0] = aAction.posX
-			f3dData[1] = aAction.posY
-			f3dData[2] = aAction.posZ
-			f3dData[3] = aAction.angX
-			f3dData[4] = aAction.angY
-			f3dData[5] = aAction.angZ
-			f3dData[6] = aAction.fScale
-		endif
-	
-		if(aAction.ObjectRef && ! aAction.ObjectRef.IsDisabled())
-			;Debug.MessageBox("Not disabled - Current position: " + aAction.ObjectRef.GetPositionX() + ", " + aAction.ObjectRef.Y + ", " + aAction.ObjectRef.Z + "; Moving to " + f3dData[0] + ", " + f3dData[1] + ", " + f3dData[2])
-			; Restore 3d settings
-			if(aAction.ObjectRef.IsCreated())
-				aAction.ObjectRef.SetPosition(f3dData[0], f3dData[1], f3dData[2])
-				aAction.ObjectRef.SetAngle(f3dData[3], f3dData[4], f3dData[5])
+	; 1.0.2 - Offering undo/redo of bulk operations
+	if(aAction.ObjectRef.HasKeyword(UndoHelperKeyword))
+		ObjectReference[] kLinkedRefs = aAction.ObjectRef.GetLinkedRefChildren(UndoHelperLinkKeyword)
+		ModTrace("[WSPlus] Attempting undo helper action: " + aAction)
+		if(kLinkedRefs.Length > 0)
+			Int iTargetLayerID
+			if(kLinkedRefs[0].IsDisabled())
+				kLinkedRefs[0].Enable(false)
+				iTargetLayerID = kLinkedRefs[0].GetValue(RecordLayerIDAV) as Int
+				kLinkedRefs[0].Disable(false) 
 			else
-				;Debug.MessageBox("Can't move this item, replacing it")
-				; Non-created items can't be moved, so instead we'll replace them
-				ObjectReference kTempMarker = aAction.ObjectRef.PlaceAtMe(XMarker)
-				ObjectReference kReplacement
-				kTempMarker.SetPosition(f3dData[0], f3dData[1], f3dData[2])
-				kTempMarker.SetAngle(f3dData[3], f3dData[4], f3dData[5])
+				iTargetLayerID = kLinkedRefs[0].GetValue(LayerIDAV) as Int
 				
-				kReplacement = kTempMarker.PlaceAtMe(aAction.BaseObject, 1, false, false, false)
-				RecordLastPosition(kReplacement)
+				if(iTargetLayerID <= 0)
+					; Check RecordLayerIDAV
+					iTargetLayerID = kLinkedRefs[0].GetValue(RecordLayerIDAV) as Int
+				endif
+			endif
+						
+			WorkshopPlus:WorkshopLayer thisLayer = LayerManager.GetLayerFromID(iTargetLayerID, thisWorkshop)
+			
+			int i = 0
+			while(i < kLinkedRefs.Length)
+				if(( ! bReverse && aAction.iAction == Action_Destroy) || (bReverse && aAction.iAction == Action_Create))
+					kLinkedRefs[i].Disable(false)
+					kLinkedRefs[i].SetLinkedRef(None, WorkshopItemKeyword)
+					if(thisLayer)						
+						LayerManager.RemoveItemFromLayer_Lock(kLinkedRefs[i], thisLayer)
+					endif
+				elseif(( ! bReverse && aAction.iAction == Action_Create) || (bReverse && aAction.iAction == Action_Destroy))
+					kLinkedRefs[i].Enable(false)
+					kLinkedRefs[i].SetLinkedRef(thisWorkshop, WorkshopItemKeyword)
+					if(thisLayer)						
+						LayerManager.AddItemToLayer_Lock(kLinkedRefs[i], thisLayer)
+					endif
+				elseif(aAction.iAction == Action_Move)
+					; TODO - Handle undoing LayerHandle moves
+				endif
 				
-				; Grab layer ID of previous object before finishing swap
-				aAction.ObjectRef.GetValue(LayerManager.LayerID)
+				i += 1
+			endWhile
+		endif
+	else
+		if(( ! bReverse && aAction.iAction == Action_Destroy) || (bReverse && aAction.iAction == Action_Create))
+			; Scrap this ref
+			int iLayerID = aAction.ObjectRef.GetValue(LayerManager.LayerID) as Int
+			
+			WorkshopParent.RemoveObjectPUBLIC(aAction.ObjectRef, thisWorkshop)
+			aAction.ObjectRef.Disable()		
+			aAction.ObjectRef.SetLinkedRef(None, WorkshopItemKeyword)
+			
+			WorkshopPlus:WorkshopLayer thisLayer = LayerManager.GetLayerFromID(iLayerID, thisWorkshop)
+			if(thisLayer)
+				LayerManager.RemoveItemFromLayer_Lock(aAction.ObjectRef, thisLayer)
+			endif
+		elseif(( ! bReverse && aAction.iAction == Action_Create) || (bReverse && aAction.iAction == Action_Destroy) || aAction.iAction == Action_Move)
+			Float[] f3dData = new Float[7]
+			int iLayerID = -1
+			
+			if(bReverse && aAction.iAction == Action_Move)
+				;Debug.MessageBox("Using previous data - " + aAction.lastPosZ + " rather than " + aAction.posZ)
+				; Grab previous coordinates from object AVs
+				f3dData[0] = aAction.lastPosX
+				f3dData[1] = aAction.lastPosY
+				f3dData[2] = aAction.lastPosZ
+				f3dData[3] = aAction.lastAngX
+				f3dData[4] = aAction.lastAngY
+				f3dData[5] = aAction.lastAngZ
+				f3dData[6] = aAction.lastfScale
+			else
+				f3dData[0] = aAction.posX
+				f3dData[1] = aAction.posY
+				f3dData[2] = aAction.posZ
+				f3dData[3] = aAction.angX
+				f3dData[4] = aAction.angY
+				f3dData[5] = aAction.angZ
+				f3dData[6] = aAction.fScale
+			endif
+		
+			if(aAction.ObjectRef && ! aAction.ObjectRef.IsDisabled())
+				;Debug.MessageBox("Not disabled - Current position: " + aAction.ObjectRef.GetPositionX() + ", " + aAction.ObjectRef.Y + ", " + aAction.ObjectRef.Z + "; Moving to " + f3dData[0] + ", " + f3dData[1] + ", " + f3dData[2])
+				; Restore 3d settings
+				if(aAction.ObjectRef.IsCreated())
+					aAction.ObjectRef.SetPosition(f3dData[0], f3dData[1], f3dData[2])
+					aAction.ObjectRef.SetAngle(f3dData[3], f3dData[4], f3dData[5])
+				else
+					;Debug.MessageBox("Can't move this item, replacing it")
+					; Non-created items can't be moved, so instead we'll replace them
+					ObjectReference kTempMarker = aAction.ObjectRef.PlaceAtMe(XMarker)
+					ObjectReference kReplacement
+					kTempMarker.SetPosition(f3dData[0], f3dData[1], f3dData[2])
+					kTempMarker.SetAngle(f3dData[3], f3dData[4], f3dData[5])
+					
+					kReplacement = kTempMarker.PlaceAtMe(aAction.BaseObject, 1, false, false, false)
+					RecordLastPosition(kReplacement)
+					
+					; Grab layer ID of previous object before finishing swap
+					aAction.ObjectRef.GetValue(LayerManager.LayerID)
+					
+					aAction.ObjectRef.Disable()
+					aAction.ObjectRef = kReplacement
+					aAction.ObjectRef.SetLinkedRef(thisWorkshop, WorkshopItemKeyword)
+					
+					thisWorkshop.OnWorkshopObjectPlaced(aAction.ObjectRef)
+					
+					kTempMarker.DisableNoWait()
+					kTempMarker.Delete()
+					kTempMarker = None
+				endif
 				
-				aAction.ObjectRef.Disable()
-				aAction.ObjectRef = kReplacement
+				aAction.ObjectRef.SetScale(f3dData[6])
+					
+				; Toggle display to fix fuzziness
+				aAction.ObjectRef.Disable(false)
+				aAction.ObjectRef.Enable(false)
+			else
+				;Debug.MessageBox("Disabled - creating new.")	
+				Bool bNewCopy = false
+				if( ! aAction.ObjectRef || aAction.ObjectRef.IsDeleted())
+					; Create new copy
+					bNewCopy = true
+					aAction.ObjectRef = thisWorkshop.PlaceAtMe(aAction.BaseObject, 1, false, true, false)
+				endif
+				
+				ModTrace("[WATCHING FOR] Repositioning " + aAction.ObjectRef + ", Using position data: " + f3dData)
+				
 				aAction.ObjectRef.SetLinkedRef(thisWorkshop, WorkshopItemKeyword)
+				aAction.ObjectRef.SetPosition(f3dData[0], f3dData[1], f3dData[2])
+				
+				if(aAction.ObjectRef as Actor)
+					; Actors must be enabled before setting angle or scale
+					aAction.ObjectRef.Enable(false)
+				endif
+				
+				aAction.ObjectRef.SetAngle(f3dData[3], f3dData[4], f3dData[5])
+				aAction.ObjectRef.SetScale(f3dData[6])
+				aAction.ObjectRef.Enable(false)
+				
+				if( ! bNewCopy) ; This object should still have its previous layer id
+					iLayerID = aAction.ObjectRef.GetValue(LayerManager.LayerID) as Int
+				endif
 				
 				thisWorkshop.OnWorkshopObjectPlaced(aAction.ObjectRef)
-				
-				kTempMarker.DisableNoWait()
-				kTempMarker.Delete()
-				kTempMarker = None
 			endif
 			
-			aAction.ObjectRef.SetScale(f3dData[6])
+			if(aAction.iAction != Action_Move)
+				; Update object on layer
+				WorkshopPlus:WorkshopLayer kLayerRef = None
+				if(iLayerID >= 1)
+					kLayerRef = LayerManager.GetLayerFromID(iLayerID, thisWorkshop)
+				endif
 				
-			; Toggle display to fix fuzziness
-			aAction.ObjectRef.Disable(false)
-			aAction.ObjectRef.Enable(false)
-		else
-			;Debug.MessageBox("Disabled - creating new.")	
-			Bool bNewCopy = false
-			if( ! aAction.ObjectRef || aAction.ObjectRef.IsDeleted())
-				; Create new copy
-				bNewCopy = true
-				aAction.ObjectRef = thisWorkshop.PlaceAtMe(aAction.BaseObject, 1, false, true, false)
+				if(kLayerRef)
+					LayerManager.AddItemToLayer_Lock(aAction.ObjectRef, kLayerRef)	
+				else
+					LayerManager.AddItemToLayer_Lock(aAction.ObjectRef)				
+				endif
+			endif
+		endif
+		
+		if(aAction.ObjectRef && ! aAction.ObjectRef.IsDeleted() && bCanBePowered)
+			; Restore power as best we can - will require F4SE to fully restore
+			aAction.ObjectRef.SetValue(PowerRequired, fPowerRequired)
+			aAction.ObjectRef.AddKeyword(WorkshopCanBePowered)
+			
+			if(bHasPowerConnection)
+				aAction.ObjectRef.AddKeyword(PowerConnection)
 			endif
 			
-			ModTrace("[WATCHING FOR] Repositioning " + aAction.ObjectRef + ", Using position data: " + f3dData)
-			
-			aAction.ObjectRef.SetLinkedRef(thisWorkshop, WorkshopItemKeyword)
-			aAction.ObjectRef.SetPosition(f3dData[0], f3dData[1], f3dData[2])
-			
-			if(aAction.ObjectRef as Actor)
-				; Actors must be enabled before setting angle or scale
+			if( ! aAction.ObjectRef.IsDisabled())
+				aAction.ObjectRef.Disable(false)
 				aAction.ObjectRef.Enable(false)
+				aAction.ObjectRef.OnPowerOn(aAction.ObjectRef)
 			endif
-			
-			aAction.ObjectRef.SetAngle(f3dData[3], f3dData[4], f3dData[5])
-			aAction.ObjectRef.SetScale(f3dData[6])
-			aAction.ObjectRef.Enable(false)
-			
-			if( ! bNewCopy) ; This object should still have its previous layer id
-				iLayerID = aAction.ObjectRef.GetValue(LayerManager.LayerID) as Int
-			endif
-			
-			thisWorkshop.OnWorkshopObjectPlaced(aAction.ObjectRef)
-		endif
-		
-		if(aAction.iAction != Action_Move)
-			; Update object on layer
-			WorkshopPlus:WorkshopLayer kLayerRef = None
-			if(iLayerID >= 1)
-				kLayerRef = LayerManager.GetLayerFromID(iLayerID, thisWorkshop)
-			endif
-			
-			if(kLayerRef)
-				LayerManager.AddItemToLayer_Lock(aAction.ObjectRef, kLayerRef)	
-			else
-				LayerManager.AddItemToLayer_Lock(aAction.ObjectRef)				
-			endif
-		endif
-	endif
-	
-	if(aAction.ObjectRef && ! aAction.ObjectRef.IsDeleted() && bCanBePowered)
-		; Restore power as best we can - will require F4SE to fully restore
-		aAction.ObjectRef.SetValue(PowerRequired, fPowerRequired)
-		aAction.ObjectRef.AddKeyword(WorkshopCanBePowered)
-		
-		if(bHasPowerConnection)
-			aAction.ObjectRef.AddKeyword(PowerConnection)
-		endif
-		
-		if( ! aAction.ObjectRef.IsDisabled())
-			aAction.ObjectRef.Disable(false)
-			aAction.ObjectRef.Enable(false)
-			aAction.ObjectRef.OnPowerOn(aAction.ObjectRef)
 		endif
 	endif
 EndFunction
@@ -763,7 +984,8 @@ Function CloneGrabbed()
 	WorkshopScript thisWorkshop = WorkshopParent.CurrentWorkshop.GetRef() as WorkshopScript
 	
 	if( ! thisWorkshop)		
-		Debug.MessageBox("Unable to clone object, no workshop found.")
+		MustBeInSettlement.Show()
+		
 		return
 	endif
 	
@@ -771,15 +993,182 @@ Function CloneGrabbed()
 		Debug.Notification("[WS Plus] You can't clone that.")
 	endif
 	
-	ObjectReference kClonedRef = kGrabbedRef.PlaceAtMe(kGrabbedRef.GetBaseObject(), abDeleteWhenAble = false)
-	kClonedRef.SetScale(kGrabbedRef.GetScale())
+	if(kGrabbedRef.HasKeyword(LayerHandleKeyword))
+		; The actual object is going to be the invisible marker only - but it's linked on that same keyword to the actual handle object
+		WorkshopPlus:ObjectReferences:LayerHandle thisLayerHandle = kGrabbedRef.GetLinkedRef(LayerHandleKeyword) as WorkshopPlus:ObjectReferences:LayerHandle
+		ObjectReference[] HandledObjectRefs = thisLayerHandle.GetLinkedRefChildren(WorkshopStackedItemParentKEYWORD)
+		
+		if(HandledObjectRefs.Length == 0)
+			; Tell player there is nothing to clone
+		elseif(HandledObjectRefs.Length == 1)
+			CloneWorkshopObject(HandledObjectRefs[0], thisWorkshop)
+		else
+			; Check settings to see if player wants the option to put this on a new layer
+			float iHandleMethod = Setting_CloneLayerHandleMethod.GetValue()
+			int iLayerIndex = 0
+			WorkshopPlus:SettlementLayers thisSettlementLayers = LayerManager.GetCurrentSettlementLayers()
+			
+			if(iHandleMethod == 0)				
+				if(thisSettlementLayers.ActiveLayer == thisSettlementLayers.DefaultLayer)
+					iLayerIndex = 0
+				else
+					iLayerIndex = thisSettlementLayers.Layers.Find(thisSettlementLayers.ActiveLayer) + 1
+				endif
+			elseif(iHandleMethod == 1)
+				if(thisLayerHandle.LayerRef == thisSettlementLayers.DefaultLayer)
+					iLayerIndex = 0
+				else
+					iLayerIndex = thisSettlementLayers.Layers.Find(thisLayerHandle.LayerRef) + 1
+				endif
+			elseif(iHandleMethod == 2)
+				LayerManager.CreateNewLayer()
+				thisSettlementLayers = LayerManager.GetCurrentSettlementLayers() ; Update our copy
+				iLayerIndex = thisSettlementLayers.Layers.Find(thisSettlementLayers.ActiveLayer) + 1
+			else
+				int iOption = CloneLayerHandleOptions.Show()
+				
+				if(iOption == 0)
+					return
+				elseif(iOption == 1)
+					LayerManager.CreateNewLayer()
+					thisSettlementLayers = LayerManager.GetCurrentSettlementLayers() ; Update our copy
+					iLayerIndex = thisSettlementLayers.Layers.Find(thisSettlementLayers.ActiveLayer) + 1
+				else
+					iLayerIndex = iOption - 2
+				endif
+			endif
+			
+			if(iLayerIndex == -2) ; Canceled
+				return
+			else
+				PrepareUndoHelper(thisWorkshop.GetWorkshopID(), iLayerIndex)
+			
+				thisLayerHandle.PlayBusyShader()
+				
+				int i = 0
+				while(i < HandledObjectRefs.Length)
+					; Copy all items
+					CloneWorkshopObject_Threaded(HandledObjectRefs[i], thisWorkshop, iLayerIndex)
+					
+					i += 1
+				endWhile
+				
+				thisLayerHandle.PlayReadyShader()
+			endif
+		endif
+	else
+		; 1.0.2 - Changing actual cloning action to separate function so we can call it in bulk
+		CloneWorkshopObject(kGrabbedRef, thisWorkshop)
+	endif
+EndFunction
+
+
+
+; 1.0.2 - Seperating this part out so we can use it for bulk cloning
+Function CloneWorkshopObject_Threaded(ObjectReference akCloneMe, WorkshopScript akWorkshopRef, Int aiLayerIndex)
+	WorkshopPlus:Threading:Thread_CopyObject kThreadRef = ThreadManager.CreateThread(Thread_CopyObject) as WorkshopPlus:Threading:Thread_CopyObject
+			
+	kThreadRef.bFadeIn = false 
+	kThreadRef.bStartEnabled = true
+	kThreadRef.kWorkshopRef = akWorkshopRef
+	kThreadRef.kSpawnAt = akCloneMe
+	kThreadRef.kCopyRef = akCloneMe
+	kThreadRef.LayerCollection = LayerItemDuplicationHolders[aiLayerIndex]
 	
-	kClonedRef.SetLinkedRef(thisWorkshop, WorkshopItemKeyword)
-	thisWorkshop.OnWorkshopObjectPlaced(kClonedRef)	
+	if(kThreadRef)
+		ThreadManager.QueueThread(kThreadRef, sThreadID_ObjectCopied)
+	endif
+EndFunction
+
+
+; 1.0.2 - Changing actual cloning action to separate function so we can call it in bulk
+ObjectReference Function CloneWorkshopObject(ObjectReference akCopyRef, WorkshopScript akWorkshopRef = None, Bool abCreateHistory = true)
+	if( ! akCopyRef)
+		return None
+	endif
 	
+	if( ! akWorkshopRef)
+		akWorkshopRef = akCopyRef.GetLinkedRef(WorkshopItemKeyword) as WorkshopScript
+		
+		if( ! akWorkshopRef)
+			return None
+		endif
+	endif
+	
+	ObjectReference kClonedRef = akCopyRef.PlaceAtMe(akCopyRef.GetBaseObject(), abInitiallyDisabled = true, abDeleteWhenAble = false)
+	kClonedRef.SetScale(akCopyRef.GetScale())
+	kClonedRef.Enable(false)
+	kClonedRef.SetLinkedRef(akWorkshopRef, WorkshopItemKeyword)
+	akWorkshopRef.OnWorkshopObjectPlaced(kClonedRef)			
 	LayerManager.AddItemToLayer_Lock(kClonedRef)
+	RecordLastPosition(kClonedRef)
 	
-	CreateHistory(kClonedRef, thisWorkshop.GetWorkshopID(), Action_Create)
+	if(abCreateHistory)
+		CreateHistory(kClonedRef, akWorkshopRef.GetWorkshopID(), Action_Create)
+	endif
+	
+	return kClonedRef
+EndFunction
+
+
+
+
+Function AddDuplicatesToLayers()
+	; Using a block function to avoid overloading the locking mechanism
+	if(bAddingDuplicatesToLayersBlock)
+		return
+	endif
+	
+	bAddingDuplicatesToLayersBlock = true
+	
+	WorkshopPlus:SettlementLayers thisSettlementLayers = LayerManager.GetCurrentSettlementLayers()
+	
+	int i = 0
+	while(i < LayerItemDuplicationHolders.Length)
+		int iCount = LayerItemDuplicationHolders[i].GetCount()
+		
+		if(iCount > 0)
+			if(thisSettlementLayers)
+				WorkshopPlus:WorkshopLayer kLayerRef = thisSettlementLayers.DefaultLayer
+				if(i > 0 && thisSettlementLayers.Layers.Length > (i - 1))
+					kLayerRef = thisSettlementLayers.Layers[(i - 1)] ; Our Duplication refcollections are indexed so that 0 = Default layer, so we need to account for that
+				endif
+				
+				int j = iCount
+				while(j > 0)
+					ObjectReference kTemp = LayerItemDuplicationHolders[i].GetAt(0)
+					
+					LayerManager.AddItemToLayer_Lock(kTemp, kLayerRef)
+					
+					RecordLastPosition(kTemp)
+					if(UndoHelperHolder[i] != None)
+						kTemp.SetLinkedRef(UndoHelperHolder[i], UndoHelperLinkKeyword)
+					endif
+					
+					ShaderFlashComplete.Play(kTemp, 2.0)
+					LayerItemDuplicationHolders[i].RemoveRef(kTemp)
+					
+					j -= 1
+				endWhile
+			endif
+		endif
+		
+		i += 1
+	endWhile
+	
+	bAddingDuplicatesToLayersBlock = false
+	
+	; Since we're using a block, there could be times when the function is running, and has already passed the added layer in the initial loops, this could result in straggler items getting left behind, so let's double check for items and if any found, schedule another check shortly in case follow-up events to trigger it never come.
+	i = 0
+	while(i < LayerItemDuplicationHolders.Length)
+		if(LayerItemDuplicationHolders[i].GetCount() > 0)
+			StartTimer(3.0, iTimerID_DoubleCheckDuplicationHolders)
+			
+			return
+		endif
+		
+		i += 1
+	endWhile
 EndFunction
 
 

--- a/Scripts/Source/User/WorkshopPlus/Fragments/Terminals/TERM_WSPlus_Advanced_Menu.psc
+++ b/Scripts/Source/User/WorkshopPlus/Fragments/Terminals/TERM_WSPlus_Advanced_Menu.psc
@@ -97,8 +97,60 @@ Setting_AutoUnlinkHiddenLayers.SetValue(1.0)
 EndFunction
 ;END FRAGMENT
 
+;BEGIN FRAGMENT Fragment_Terminal_13
+Function Fragment_Terminal_13(ObjectReference akTerminalRef)
+;BEGIN CODE
+Setting_HighlightLayerHandleSelectedObjects.SetValue(0.0)
+;END CODE
+EndFunction
+;END FRAGMENT
+
+;BEGIN FRAGMENT Fragment_Terminal_14
+Function Fragment_Terminal_14(ObjectReference akTerminalRef)
+;BEGIN CODE
+Setting_HighlightLayerHandleSelectedObjects.SetValue(1.0)
+;END CODE
+EndFunction
+;END FRAGMENT
+
+;BEGIN FRAGMENT Fragment_Terminal_15
+Function Fragment_Terminal_15(ObjectReference akTerminalRef)
+;BEGIN CODE
+Setting_CloneLayerHandleMethod.SetValue(1.0)
+;END CODE
+EndFunction
+;END FRAGMENT
+
+;BEGIN FRAGMENT Fragment_Terminal_16
+Function Fragment_Terminal_16(ObjectReference akTerminalRef)
+;BEGIN CODE
+Setting_CloneLayerHandleMethod.SetValue(2.0)
+;END CODE
+EndFunction
+;END FRAGMENT
+
+;BEGIN FRAGMENT Fragment_Terminal_17
+Function Fragment_Terminal_17(ObjectReference akTerminalRef)
+;BEGIN CODE
+Setting_CloneLayerHandleMethod.SetValue(3.0)
+;END CODE
+EndFunction
+;END FRAGMENT
+
+;BEGIN FRAGMENT Fragment_Terminal_18
+Function Fragment_Terminal_18(ObjectReference akTerminalRef)
+;BEGIN CODE
+Setting_CloneLayerHandleMethod.SetValue(0.0)
+;END CODE
+EndFunction
+;END FRAGMENT
+
 ;END FRAGMENT CODE - Do not edit anything between this and the begin comment
 
 GlobalVariable Property Setting_AutosaveDelay Auto Const
 
 GlobalVariable Property Setting_AutoUnlinkHiddenLayers Auto Const
+
+GlobalVariable Property Setting_HighlightLayerHandleSelectedObjects Auto Const
+
+GlobalVariable Property Setting_CloneLayerHandleMethod Auto Const

--- a/Scripts/Source/User/WorkshopPlus/ObjectReferences/LayerHandle.psc
+++ b/Scripts/Source/User/WorkshopPlus/ObjectReferences/LayerHandle.psc
@@ -1,0 +1,203 @@
+; ---------------------------------------------
+; WorkshopPlus:ObjectReferences:LayerHandle.psc - by kinggath
+; ---------------------------------------------
+; Reusage Rights ------------------------------
+; You are free to use this script or portions of it in your own mods, provided you give me credit in your description and maintain this section of comments in any released source code (which includes the IMPORTED SCRIPT CREDIT section to give credit to anyone in the associated Import scripts below.
+; 
+; Warning !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+; Do not directly recompile this script for redistribution without first renaming it to avoid compatibility issues issues with the mod this came from.
+; 
+; IMPORTED SCRIPT CREDIT
+; N/A
+; ---------------------------------------------
+
+Scriptname WorkshopPlus:ObjectReferences:LayerHandle extends WorkshopFramework:ObjectRefs:InvisibleWorkshopObject
+{ Allows picking up all items on a layer }
+
+import WorkshopFramework:Library:UtilityFunctions
+import WorkshopFramework:Library:DataStructures
+
+; ---------------------------------------------
+; Consts 
+; ---------------------------------------------
+
+
+; ---------------------------------------------
+; Editor Properties 
+; ---------------------------------------------
+
+Group Controllers
+	WorkshopPlus:LayerManager Property LayerManager Auto Const Mandatory
+EndGroup
+
+Group Keywords
+	Keyword Property LayerHandleKeyword Auto Const Mandatory
+	Keyword Property WorkshopStackedItemParentKEYWORD Auto Const Mandatory
+	Keyword Property LayerItemLinkChainKeyword Auto Const Mandatory
+	{ Same as LayerItemLinkChainKeyword on LayerManager }
+	Keyword Property AddedToLayerKeyword Auto Const Mandatory
+	{ Same as AddedToLayerKeyword on LayerManager }
+	Keyword Property WorkshopItemKeyword Auto Const Mandatory
+EndGroup
+
+Group ActorValues
+	ActorValue Property LayerIDAV Auto Const Mandatory
+EndGroup
+
+Group Assets
+	EffectShader Property AttachingShader Auto Const Mandatory
+	{ Shader that will show on the handle while it is grabbing items and will also flash on each item as it is added }
+	EffectShader Property BusyShader Auto Const Mandatory
+	{ Shader that will appear on the handle when it should not be moved }
+	EffectShader Property ReadyShader Auto Const Mandatory
+	{ Shader that will appear on the handle when it has finished it's task }
+EndGroup
+
+Group Settings
+	Float Property fLinkRadius Auto Const Mandatory
+	{ Radius around the handle to link items. }
+EndGroup
+
+
+
+; ---------------------------------------------
+; Vars
+; ---------------------------------------------
+
+Int Property iLayerID = -1 Auto Hidden
+WorkshopPlus:WorkshopLayer Property LayerRef Auto Hidden
+Bool bFirstLoad = true
+
+; ---------------------------------------------
+; Events
+; ---------------------------------------------
+
+Event OnInit()
+	Parent.OnInit()
+	
+	kControlledRef.SetLinkedRef(Self, LayerHandleKeyword) ; Link to the controlled ref from InvisibleWorkshopObject so we can access it from ActionManager
+	AddKeyword(LayerHandleKeyword)	
+EndEvent
+
+
+Event OnLoad()
+	Parent.OnLoad()
+	
+	if(bFirstLoad)
+		bFirstLoad = false
+		
+		; Check for layerID and workshopID
+		WorkshopScript thisWorkshop = GetLinkedRef(WorkshopItemKeyword) as WorkshopScript
+			
+		if(workshopID < 0)				
+			workshopID = thisWorkshop.GetWorkshopID()
+		endif
+		
+		WorkshopPlus:SettlementLayers thisSettlementLayers = LayerManager.GetCurrentSettlementLayers()
+		LayerRef = thisSettlementLayers.ActiveLayer
+		
+		
+		if(LayerRef)
+			LayerRef.LayerHandle = Self
+			iLayerID = LayerRef.iLayerID
+			AttachObjects()
+		endif
+	endif
+EndEvent
+
+
+; ---------------------------------------------
+; Functions
+; ---------------------------------------------
+
+Function AttachObjects()
+	PlayBusyShader()
+	
+	Float fRadius = fLinkRadius
+	
+	if(fRadius > 0)
+		; Grab items within radius and test for layerID
+		ObjectReference[] NearbyRefs = FindAllReferencesWithKeyword(AddedToLayerKeyword, fRadius)
+		
+		int i = 0
+		while(i < NearbyRefs.Length)
+			if(NearbyRefs[i].GetValue(LayerIDAV) == iLayerID)
+				AttachingShader.Play(NearbyRefs[i], 1.0)
+				NearbyRefs[i].SetLinkedRef(Self, WorkshopStackedItemParentKEYWORD)
+			endif
+			
+			i += 1
+		endWhile
+	else
+		; Just attach all items on layer
+		ObjectReference kNextRef = LayerRef.kLastCreatedItem
+		while(kNextRef)
+			AttachingShader.Play(kNextRef, 1.0)
+			kNextRef.SetLinkedRef(Self, WorkshopStackedItemParentKEYWORD)
+			kNextRef = kNextRef.GetLinkedRef(LayerItemLinkChainKeyword)
+		endWhile
+	endif
+	
+	PlayReadyShader()
+EndFunction
+
+Function PlayBusyShader(Float afTime = -1.0)
+	if(Self.kControlledRef)
+		BusyShader.Play(Self.kControlledRef, afTime)
+	endif
+EndFunction
+
+Function PlayReadyShader(Float afTime = 1.0)
+	if(Self.kControlledRef)
+		BusyShader.Stop(Self.kControlledRef) ; Clear busy shader
+	endif
+	
+	Utility.Wait(2.0) ; wait for busy shader to fade out
+	
+	if(Self.kControlledRef)
+		ReadyShader.Play(Self.kControlledRef, afTime)
+	endif
+EndFunction
+
+Function DetachObjects()
+	ObjectReference[] StackedRefs = GetLinkedRefChildren(WorkshopStackedItemParentKEYWORD)
+	
+	int i = 0
+	while(i < StackedRefs.Length)
+		StackedRefs[i].SetLinkedRef(None, WorkshopStackedItemParentKEYWORD)
+		
+		i += 1
+	endWhile
+EndFunction
+
+
+Function Hide()
+	Self.MoveTo(Self, 0.0, 0.0, -10000.0)
+	kControlledRef.MoveTo(Self)
+EndFunction
+
+
+Function Disable(Bool abFade = false)
+	Cleanup()
+	
+	Parent.Disable(abFade)
+EndFunction
+
+Function DisableNoWait(Bool abFade = false)
+	Cleanup()
+	
+	Parent.DisableNoWait(abFade)
+EndFunction
+
+Function Cleanup()
+	Parent.Cleanup()
+	
+	if(LayerRef && LayerRef.LayerHandle == Self)
+		LayerRef.LayerHandle = None
+	endif
+	
+	DetachObjects()
+	
+	kControlledRef = None
+	LayerRef = None
+EndFunction

--- a/Scripts/Source/User/WorkshopPlus/ObjectReferences/LayerHandleMarker.psc
+++ b/Scripts/Source/User/WorkshopPlus/ObjectReferences/LayerHandleMarker.psc
@@ -1,0 +1,83 @@
+; ---------------------------------------------
+; WorkshopPlus:ObjectReferences:LayerHandleMarker.psc - by kinggath
+; ---------------------------------------------
+; Reusage Rights ------------------------------
+; You are free to use this script or portions of it in your own mods, provided you give me credit in your description and maintain this section of comments in any released source code (which includes the IMPORTED SCRIPT CREDIT section to give credit to anyone in the associated Import scripts below.
+; 
+; Warning !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+; Do not directly recompile this script for redistribution without first renaming it to avoid compatibility issues issues with the mod this came from.
+; 
+; IMPORTED SCRIPT CREDIT
+; N/A
+; ---------------------------------------------
+
+Scriptname WorkshopPlus:ObjectReferences:LayerHandleMarker extends WorkshopObjectScript
+{ Actual object players interact with }
+
+
+Keyword Property LinkHandleKeyword Auto Const Mandatory
+Keyword Property WorkshopStackedItemParentKeyword Auto Const Mandatory
+GlobalVariable Property Setting_HighlightLayerHandleSelectedObjects Auto Const Mandatory
+EffectShader Property GrabbedShader Auto Const Mandatory
+
+
+Event OnWorkshopObjectGrabbed(ObjectReference akWorkshopRef)
+	WorkshopPlus:ObjectReferences:LayerHandle thisLayerHandle = GetLinkedRef(LinkHandleKeyword) as WorkshopPlus:ObjectReferences:LayerHandle
+	
+	if(thisLayerHandle)
+		if(Setting_HighlightLayerHandleSelectedObjects.GetValue() == 1.0)
+			; Highlight all objects
+			ObjectReference[] AttachedObjects = thisLayerHandle.GetLinkedRefChildren(WorkshopStackedItemParentKEYWORD)
+		
+			int i = 0
+			while(i < AttachedObjects.Length)
+				GrabbedShader.Play(AttachedObjects[i], -1.0)
+				
+				i += 1
+			endWhile
+		endif
+	endif
+EndEvent
+
+Event OnWorkshopObjectMoved(ObjectReference akWorkshopRef)
+	WorkshopPlus:ObjectReferences:LayerHandle thisLayerHandle = GetLinkedRef(LinkHandleKeyword) as WorkshopPlus:ObjectReferences:LayerHandle
+	
+	; Disconnect in case the player stores it - that way the objects attached won't get stored
+	if(thisLayerHandle)
+		; Make sure the handle stays linked in case we pick up the marker again
+		thisLayerHandle.SetLinkedRef(Self, WorkshopStackedItemParentKEYWORD)
+		
+		; Unhighlight all objects
+		if(Setting_HighlightLayerHandleSelectedObjects.GetValue() == 1.0)
+			; Highlight all objects
+			ObjectReference[] AttachedObjects = thisLayerHandle.GetLinkedRefChildren(WorkshopStackedItemParentKEYWORD)
+		
+			int i = 0
+			while(i < AttachedObjects.Length)
+				GrabbedShader.Stop(AttachedObjects[i])
+				
+				i += 1
+			endWhile
+		endif
+	endif
+EndEvent
+
+Event OnWorkshopObjectDestroyed(ObjectReference akWorkshopRef)
+	Self.Delete()
+EndEvent
+
+
+Function Delete()
+	Cleanup()
+	
+	Parent.Delete()
+EndFunction
+
+Function Cleanup()
+	WorkshopPlus:ObjectReferences:LayerHandle thisLayerHandle = GetLinkedRef(LinkHandleKeyword) as WorkshopPlus:ObjectReferences:LayerHandle
+	
+	Self.SetLinkedRef(None, LinkHandleKeyword)
+	Self.SetLinkedRef(None, WorkshopStackedItemParentKEYWORD)
+	
+	thisLayerHandle.Cleanup()	
+EndFunction

--- a/Scripts/Source/User/WorkshopPlus/ObjectReferences/LayerHandlePlacer.psc
+++ b/Scripts/Source/User/WorkshopPlus/ObjectReferences/LayerHandlePlacer.psc
@@ -1,0 +1,70 @@
+; ---------------------------------------------
+; WorkshopPlus:ObjectReferences:LayerHandlePlacer.psc - by kinggath
+; ---------------------------------------------
+; Reusage Rights ------------------------------
+; You are free to use this script or portions of it in your own mods, provided you give me credit in your description and maintain this section of comments in any released source code (which includes the IMPORTED SCRIPT CREDIT section to give credit to anyone in the associated Import scripts below.
+; 
+; Warning !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+; Do not directly recompile this script for redistribution without first renaming it to avoid compatibility issues issues with the mod this came from.
+; 
+; IMPORTED SCRIPT CREDIT
+; N/A
+; ---------------------------------------------
+
+Scriptname WorkshopPlus:ObjectReferences:LayerHandlePlacer extends ObjectReference Const
+{ Places the layer handle corresponding to the current layer, and then self-destructs }
+
+
+import WorkshopFramework:WorkshopFunctions
+
+Form[] Property LayerHandlerForms Auto Const Mandatory
+WorkshopPlus:LayerManager Property LayerManager Auto Const Mandatory
+Keyword Property WorkshopItemKeyword Auto Const Mandatory
+Message Property DefaultLayerWarningConfirm Auto Const Mandatory
+
+Event OnInit()
+	WorkshopPlus:SettlementLayers thisSettlementLayers = LayerManager.GetCurrentSettlementLayers()	
+	
+	int iIndex = thisSettlementLayers.Layers.Find(thisSettlementLayers.ActiveLayer)
+	ObjectReference kHandle
+	
+	if(iIndex < 0)
+		iIndex = 0
+		
+		kHandle = thisSettlementLayers.DefaultLayer.LayerHandle
+	else
+		kHandle = thisSettlementLayers.Layers[iIndex].LayerHandle
+		
+		iIndex += 1
+	endif
+	
+	if( ! kHandle)
+		bool bCreateHandle = true
+		if(iIndex == 0)
+			Int iConfirm = DefaultLayerWarningConfirm.Show()
+			
+			if(iConfirm == 0)
+				bCreateHandle = false
+			endif
+		endif
+		
+		if(bCreateHandle)
+			kHandle = PlaceAtMe(LayerHandlerForms[iIndex], abInitiallyDisabled = true, abDeleteWhenAble = false)
+			kHandle.SetLinkedRef(GetNearestWorkshop(Self), WorkshopItemKeyword)
+			kHandle.Enable(false)
+		endif
+	else ; Bring the existing handle over to the player
+		kHandle.MoveTo(Self)
+		WorkshopPlus:ObjectReferences:LayerHandle asHandle = kHandle as WorkshopPlus:ObjectReferences:LayerHandle
+		
+		if(asHandle)
+			asHandle.kControlledRef.MoveTo(kHandle)
+			if(asHandle.fLinkRadius <= 0)
+				asHandle.AttachObjects() ; Attach any new objects on the layer
+			endif
+		endif
+	endif
+	
+	Disable(false)
+	Delete()
+EndEvent

--- a/Scripts/Source/User/WorkshopPlus/SettlementLayers.psc
+++ b/Scripts/Source/User/WorkshopPlus/SettlementLayers.psc
@@ -29,10 +29,14 @@ Bool Property bDeletedByManager = false Auto Hidden ; Flag in case we need to de
 
 Function Disable(Bool abFade = false)
 	Cleanup()
+	
+	Parent.Disable(abFade) ; 1.0.2 - Ensure actual disable takes place
 EndFunction
 
 Function DisableNoWait(Bool abFade = false)
 	Cleanup()
+	
+	Parent.DisableNoWait(abFade) ; 1.0.2 - Ensure actual disable takes place
 EndFunction
 
 Function Cleanup()

--- a/Scripts/Source/User/WorkshopPlus/Threading/Thread_CopyObject.psc
+++ b/Scripts/Source/User/WorkshopPlus/Threading/Thread_CopyObject.psc
@@ -1,0 +1,65 @@
+; ---------------------------------------------
+; WorkshopPlus:Threading:Thread_CopyObject.psc - by kinggath
+; ---------------------------------------------
+; Reusage Rights ------------------------------
+; You are free to use this script or portions of it in your own mods, provided you give me credit in your description and maintain this section of comments in any released source code (which includes the IMPORTED SCRIPT CREDIT section to give credit to anyone in the associated Import scripts below).
+; 
+; Warning !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+; Do not directly recompile this script for redistribution without first renaming it to avoid compatibility issues with the mod this came from.
+; 
+; IMPORTED SCRIPT CREDITS
+; N/A
+; ---------------------------------------------
+
+Scriptname WorkshopPlus:Threading:Thread_CopyObject extends WorkshopFramework:ObjectRefs:Thread_PlaceObject
+
+; -
+; Consts
+; -
+
+
+; - 
+; Editor Properties
+; -
+
+EffectShader Property HighlightShader Auto Const
+
+; -
+; Properties
+; -
+
+ObjectReference Property kCopyRef Auto Hidden
+RefCollectionAlias Property LayerCollection Auto Hidden
+
+Function RunCode()
+	; Gather data for sending to the parent Thread_PlaceObject version
+	Self.SpawnMe = kCopyRef.GetBaseObject()
+	Self.fPosX = kCopyRef.X
+	Self.fPosY = kCopyRef.Y
+	Self.fPosZ = kCopyRef.Z
+	Self.fAngleX = kCopyRef.GetAngleX()
+	Self.fAngleY = kCopyRef.GetAngleY()
+	Self.fAngleZ = kCopyRef.GetAngleZ()
+	Self.fScale = kCopyRef.GetScale()
+	
+	; Call parent version	
+	Parent.RunCode()
+	if(kResult != None)
+		ObjectReference kTemp = kResult
+		
+		if(HighlightShader)
+			HighlightShader.Play(kTemp, 2.0)
+		endif
+		
+		LayerCollection.AddRef(kTemp)
+	endif
+	
+	SelfDestruct()
+EndFunction
+
+
+Function ReleaseObjectReferences()
+	kCopyRef = None
+
+	Parent.ReleaseObjectReferences()
+EndFunction

--- a/Scripts/Source/User/WorkshopPlus/WorkshopLayer.psc
+++ b/Scripts/Source/User/WorkshopPlus/WorkshopLayer.psc
@@ -26,13 +26,19 @@ EffectShader Property CurrentHighlightShader = None Auto Hidden
 
 Bool Property bDeletedByManager = false Auto Hidden ; Used by LayerManager to tell the layer it has already taken care of the link chain
 
+; 1.0.2 - Storing the latest handle in the layer so we can attach/remove any items as they are added
+ObjectReference Property LayerHandle Auto Hidden
 
 Function Disable(Bool abFade = false)
 	Cleanup()
+	
+	Parent.Disable(abFade) ; 1.0.2 - Ensure actual disable takes place
 EndFunction
 
 Function DisableNoWait(Bool abFade = false)
 	Cleanup()
+	
+	Parent.DisableNoWait(abFade) ; 1.0.2 - Ensure actual disable takes place
 EndFunction
 
 Function Cleanup()
@@ -40,5 +46,6 @@ Function Cleanup()
 		LayerManager.LayerDeleted(Self, abPlayerInitiatedDeletion = false)
 	endif
 	
+	LayerHandle = None
 	kLastCreatedItem = None
 EndFunction


### PR DESCRIPTION
-Fixed a bug with Clear Highlighting on Workshop Exit that made it not work at all, nor would the settings change save.
-Greatly improved the layer duplication code. Should be substantially faster, and will no longer back up the script queue.
WS+ will now post a warning pop-up if you forget to update Workshop Framework to the version it requires.
-Added Layer Handles.
--Layer Handles allow picking up and even cloning a layer.
--Layer Handles can be built in workshop mode, or hotkeyed with MCM.
--When a Layer Handle is built, it will switch to a version with the active layer number floating over it. It will then attach itself to all items on the current layer.
--The Layer Handle model is special. It has a square around the number that will highlight red when you should NOT move it, and flash green once it’s OK for you to move it again.
---There are currently two times when you shouldn’t move it:
----After you first build it and it is attaching all items (you will see the items flash blue as they are attached). Moving during this will cause some items not to be attached.
----When you are cloning the layer handle. Moving during this will cause some items to not clone in the positions they were at when you pressed the button as it takes a few seconds to copy all of the coordinates.
--WARNING - It is not recommended to pick up the Default Layer handle unless you had scrapped the entire settlement. Any objects that aren’t buildable in Workshop Mode will disappear when you pick up the layer handle. This means scrappable objects or things you can’t built yourself, such as items placed by Sim Settlements City Plan. This is an engine limitation.
--When you pick up a Layer Handle, all of the items that you will be moving will highlight green, similar to the highlight that happens when you group select in workshop mode.
--WARNING - Do NOT store the layer handle. Doing so will cause all attached items to be scrapped or stored in the workbench. Once a Layer Handle exists in a settlement, it should never be removed. Layer ---Handles will autohide themselves when you exit workshop mode.
--Notes when cloning a Layer Handle:
---It will attempt to clone all items attached to the layer handle where they are at the time you pressed the Clone Key. Wait for the layer handle status to turn green before moving.
---If the items are being cloned to the same layer the handle is for, those items will not be connected to the layer handle.
---To connect new items to a layer handle, simply place the layer handle again, and it will connect everything on the layer to itself.
-Undo/Redo will now support undoing/redoing cloning a group of objects via the Layer Handles or Duplicate Layer functionality.
--Items created via bulk cloning (duplicate layer/cloning a layer handle) will become disconnected from the bulk undo possibility if you move or scrap them independently. This may change in the future, but tracking this is quite complex and can result in potential memory leaks if not done correctly.
--Just like other Undo/Redo actions, the bulk undo/redo stack is cleared when you enter a new settlement.
--WARNING: Undo/Redo does not currently work with moving objects via a Layer Handle, but that is planned for a future update.
-Added new options to MCM/Holotape:
--Clone Layer Handle Method: This let’s you configure which layer items attached to a layer handle should be cloned to. The options are as follows:
---Active Layer [Default] - Items will be cloned to the active layer.
---Source Layer - Items will be cloned to the same layer the originals are on.
---New Layer - WS+ will attempt to create a new layer and clone to that new layer. If no new layer slots are available, the items will be cloned to the default layer.
---Ask Me - You will be prompted to select how to handle the cloned objects.
--Highlight Items When Layer Handle Held: Allows you to turn off the highlighting of items when picked up via a Layer Handle.
-Added proper messages to Undo/Redo instead of relying on Debug messages. This is in preparation for a future update where support for Undo/Redo is added to Xbox.