### PR TITLE
1.0.12

### DIFF
--- a/Scripts/Source/User/WorkshopPlus/Fragments/Terminals/TERM_WSPlus_Options_Menu.psc
+++ b/Scripts/Source/User/WorkshopPlus/Fragments/Terminals/TERM_WSPlus_Options_Menu.psc
@@ -235,6 +235,30 @@ WSPlusMain.ToggleFreeBuildMode(None, true)
 EndFunction
 ;END FRAGMENT
 
+;BEGIN FRAGMENT Fragment_Terminal_30
+Function Fragment_Terminal_30(ObjectReference akTerminalRef)
+;BEGIN CODE
+ActionManager.UndoSystemSettingChange(2)
+;END CODE
+EndFunction
+;END FRAGMENT
+
+;BEGIN FRAGMENT Fragment_Terminal_31
+Function Fragment_Terminal_31(ObjectReference akTerminalRef)
+;BEGIN CODE
+ActionManager.UndoSystemSettingChange(0)
+;END CODE
+EndFunction
+;END FRAGMENT
+
+;BEGIN FRAGMENT Fragment_Terminal_32
+Function Fragment_Terminal_32(ObjectReference akTerminalRef)
+;BEGIN CODE
+ActionManager.UndoSystemSettingChange(1)
+;END CODE
+EndFunction
+;END FRAGMENT
+
 ;END FRAGMENT CODE - Do not edit anything between this and the begin comment
 
 GlobalVariable Property Setting_AutoSaveTimer Auto Const
@@ -257,3 +281,4 @@ GlobalVariable Property Setting_AutoClearWeather Auto Const Mandatory
 
 GlobalVariable Property Setting_FreeBuildAllSettlements Auto Const Mandatory
 WorkshopPlus:MainQuest Property WSPlusMain Auto Const Mandatory
+WorkshopPlus:ActionManager Property ActionManager Auto Const Mandatory

--- a/Scripts/Source/User/WorkshopPlus/MainQuest.psc
+++ b/Scripts/Source/User/WorkshopPlus/MainQuest.psc
@@ -79,7 +79,8 @@ EndGroup
 
 Group ActorValues
 	ActorValue Property FallingDamageMod Auto Const Mandatory
-	{ Autofill }	
+	{ Autofill }
+	ActorValue Property Rads Auto Const Mandatory
 EndGroup
 
 Group Keywords
@@ -509,7 +510,11 @@ Function EnableFlight()
 		LastKnownRace = PlayerRef.GetRace()
 	endif
 	
-	if(WorkshopFramework:WSFW_API.IsPlayerInWorkshopMode() && PlayerRef.GetRace() == LastKnownRace)
+	; 1.0.12 - Removing the IsPlayerInWorkshopMode check as it can very easily get out of sync
+	if(PlayerRef.GetRace() == LastKnownRace)
+		int iRadsToHeal = (PlayerRef.GetValue(Rads) as int)
+		PlayerRef.RestoreValue(Rads, iRadsToHeal)
+		
 		Game.ForceFirstPerson()
 		PlayerRef.SetRace(FloatingRace)
 		PlayerFootsteps.Mute()


### PR DESCRIPTION
- Tweaked the Flight system slightly to make it less likely that it fails to enable when entering workshop mode.
- Undo/Redo system is now disabled by default for new games, this is due to the fact that it persists items in a way that may be unexpected by other mods. Attempting to use it for the first time will trigger a warning explaining that it needs to be enabled.
- Undo/Redo system now has 3 modes available in the settings menu: Enabled, Disabled, Enabled for Non-Power Items. 
- Fixed a bug that would cause the first time Undo was pressed to show the “Nothing to Redo” message instead of “Nothing to Undo”.
- Rads will now be cleared from the player before entering Flight mode. This is an attempt to fix a bug some players were running into where they would end up at 0 health while entering Flight mode with radiation.
If the player tracks items for a companion and then recruits that companion, the item tracking will now be cleared automatically for them.
