### PR TITLE
Flight mode stores and reapplies player's rad level.

### DIFF
--- a/Scripts/Source/User/WorkshopPlus/MainQuest.psc
+++ b/Scripts/Source/User/WorkshopPlus/MainQuest.psc
@@ -276,6 +276,9 @@ Bool bBoostCarryWeightBuffApplied = false
 Float fPreviousTimeScale = 0.0
 Bool bTimeFrozen = false
 
+; [Unknown Zombie] Change for 1.0.12 to restore rads on flight mode exit. -- Store player's Rad level.
+int iPlayerRads = 0
+
 ; ---------------------------------------------
 ; Events
 ; --------------------------------------------- 
@@ -512,8 +515,9 @@ Function EnableFlight()
 	
 	; 1.0.12 - Removing the IsPlayerInWorkshopMode check as it can very easily get out of sync
 	if(PlayerRef.GetRace() == LastKnownRace)
-		int iRadsToHeal = (PlayerRef.GetValue(Rads) as int)
-		PlayerRef.RestoreValue(Rads, iRadsToHeal)
+		; [Unknown Zombie] Change for 1.0.12 -- Save player Rad level before healing.
+		iPlayerRads = (PlayerRef.GetValue(Rads) as int)
+		PlayerRef.RestoreValue(Rads, iPlayerRads)
 		
 		Game.ForceFirstPerson()
 		PlayerRef.SetRace(FloatingRace)
@@ -544,6 +548,9 @@ Function DisableFlight()
 		else
 			PlayerRef.SetRace(HumanRace)
 		endif
+		
+		; [Unkown Zombie] Change for 1.0.12 -- Give stored Rad level back to player after becoming Human again.
+		PlayerRef.DamageValue(Rads, iPlayerRads)
 	endif		
 EndFunction
 


### PR DESCRIPTION
Entering flight mode stores player's rad level before curing all rads. Exiting flight mode reapplies player's stored rad level.

Proposed solution for the concerns that I raised about free heals in #27.

In testing, this works properly in all situations. Player's rad level is preserved through entering and exiting workshop mode with flying enabled and it also works when manually toggling flight mode without leaving workshop mode.

I don't know if this was really the best way to go about it, but it works and I didn't want to be a complainer that offers nothing back.